### PR TITLE
Fix PHP short tag in routes file

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,4 +1,4 @@
-<?
+<?php
 
 use App\Http\Controllers\LoginController;
 use App\Http\Controllers\PostController;


### PR DESCRIPTION
## Summary
- fix `routes/api.php` to start with `<?php` instead of `<?`

## Testing
- `php -l routes/api.php`
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_688a08568d948328b53d478dec0db5a8